### PR TITLE
Dockerised this repository.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+Dockerfile
+.dockerignore
+.gitignore
+README.md
+build
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:alpine
+
+# Create work directory
+RUN mkdir /src/
+WORKDIR /src/
+COPY . /src/
+
+# Install and configure serve
+RUN npm install -g serve
+CMD ["serve", "-p 8000", "-s build"]
+EXPOSE 8000
+
+# Install dependencies
+RUN npm install
+
+# Build react files
+RUN npm run build --production

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Installation
+# Wolfbeacon Analytics Dashboard
+
+This React app aggregates all the API data and presents it in a visually pleasing form.
+
+#### Running in development
 
 - Clone the repository
 
@@ -16,7 +20,21 @@
 - Run the compiled frontend 
 
   ```bash
-  npm start	
+  npm start
   ```
 
-- Open your browser and head over to `http://localhost:3000/`
+#### Running in production using Docker
+
+- Build a docker image
+
+  ```
+  docker build -t wolfbeacon-analytics-dashboard .
+  ```
+
+- Run the docker image
+
+  ```
+  docker run -p 8000:8000 wolfbeacon-analytics-dashboard
+  ```
+
+The website should be up and running on *localhost:3000*

--- a/package.json
+++ b/package.json
@@ -1,5 +1,12 @@
 {
   "name": "wolfbeacon-analytics-dashboard",
+  "description": "This React app aggregates all the API data and presents it in a visually pleasing form.",
+  "main": "src/app.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/wolfbeacon/wolfbeacon-analytics-dashboard.git"
+  },
+  "license": "GPL",
   "version": "0.1.0",
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Can now build and run as a docker container using
```
docker build -t wolfbeacon-analytics-dashboard .
docker run -p 8000:8000 wolfbeacon-analytics-dashboard
```
How React works here is, we will be serving just a single HTML in which the javascript handles the routing and dynamic stuff. 
So for serving just the single HTML file, I have used the **serve** module. 
Is it okay or should I create a Node server?